### PR TITLE
Fix duplicate correspondences counting

### DIFF
--- a/kapture_localization/localization/correspondences.py
+++ b/kapture_localization/localization/correspondences.py
@@ -123,7 +123,7 @@ def get_correspondences(kapture_data: kapture.Kapture, keypoints_type: str,
                 else:
                     # kpid_query not in assigned_3d_points_ids[p3did]
                     same_3d_multiple_2d_count += 1
-                    assigned_3d_points_ids[p3did].add(p3did)
+                    assigned_3d_points_ids[p3did].add(kpid_query)
                     same_3d_multiple_2d_max = max(same_3d_multiple_2d_max, len(assigned_3d_points_ids[p3did]))
 
             if kpts_query is not None:

--- a/kapture_localization/localization/reprojection_error.py
+++ b/kapture_localization/localization/reprojection_error.py
@@ -14,8 +14,9 @@ def compute_reprojection_error(pose: kapture.PoseTransform, num_inliers: int, in
     compute reprojection error from a pose, a list of inlier indexes, the full list of 2D points and 3D points
     and camera parameters
     """
-    obs_2D = np.empty((num_inliers, 2), dtype=np.float)
-    obs_3D = np.empty((1, num_inliers, 3), dtype=np.float)
+    # ``np.float`` was deprecated in numpy 1.20.
+    obs_2D = np.empty((num_inliers, 2), dtype=np.float64)
+    obs_3D = np.empty((1, num_inliers, 3), dtype=np.float64)
     for i, index in enumerate(inliers):
         obs_2D[i, :] = points2D[index]
         obs_3D[0, i, :] = points3D[index]

--- a/kapture_localization/matching/matching.py
+++ b/kapture_localization/matching/matching.py
@@ -46,5 +46,6 @@ class MatchPairNnTorch(MatchPairGenerator):
             [ids1[mask].type(torch.float), nearest_neighbor_idx_1vs2[mask].type(torch.float), scores[mask]]).t()
         # retrieve data back from GPU
         matches = matches_torch.data.cpu().numpy()
-        matches = matches.astype(np.float)
+        # ``np.float`` is deprecated since numpy 1.20
+        matches = matches.astype(np.float64)
         return matches

--- a/tests/test_correspondences.py
+++ b/tests/test_correspondences.py
@@ -1,0 +1,41 @@
+import unittest
+import numpy as np
+import kapture
+import path_to_kapture_localization  # noqa: F401, to set path
+from kapture_localization.localization.correspondences import get_correspondences
+from kapture_localization.localization.DuplicateCorrespondencesStrategy import DuplicateCorrespondencesStrategy
+from kapture_localization.localization.RerankCorrespondencesStrategy import RerankCorrespondencesStrategy
+from kapture.io.tar import TarCollection
+from unittest import mock
+
+class TestCorrespondences(unittest.TestCase):
+    def test_same_3d_multiple_2d(self):
+        # minimal kapture with one map image and one query image
+        k_data = kapture.Kapture(
+            matches={'kp': kapture.Matches()},
+            points3d=kapture.Points3d(np.array([[0.0, 0.0, 0.0]]))
+        )
+        k_data.matches['kp'].add('query', 'map')
+
+        # mapping of map keypoints to 3D point (both keypoints refer to same 3D id)
+        point_id_from_obs = {('map', 0): 0, ('map', 1): 0}
+
+        kpts_query = np.zeros((3, 2))
+
+        fake_matches = np.array([[0, 0, 1.0], [1, 1, 1.0]], dtype=float)
+
+        with mock.patch('kapture_localization.localization.correspondences.get_matches_fullpath',
+                        return_value='dummy'), \
+             mock.patch('kapture_localization.localization.correspondences.image_matches_from_file',
+                        return_value=fake_matches):
+            _, _, _, stats = get_correspondences(
+                k_data, 'kp', '', TarCollection(), 'query', ['map'],
+                point_id_from_obs, kpts_query, None,
+                DuplicateCorrespondencesStrategy.keep,
+                RerankCorrespondencesStrategy.none)
+
+        self.assertEqual(stats['same_3d_multiple_2d_count'], 1)
+        self.assertEqual(stats['same_3d_multiple_2d_max'], 2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix `get_correspondences` when several 2D observations correspond to the same 3D point
- add regression test for correspondences statistics
- replace deprecated `np.float` usage with `np.float64`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841a75fa2e0832a89907064c6e32444